### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: squisty/olympic_medal_htest # change this to your DockerHub username and repository
         username: ${{ secrets.DOCKER_USERNAME }} # you need to add your Docker username to this GitHub repo as a secret

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ The local repository can be reset to the initial cloned state by running:
 ```
 make clean
 ```
+### File dependency diagram
+Please see below for our file dependencies:
 
+![Dependency Diagram](Makefile.png)
 
 ## Dependencies
 


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore